### PR TITLE
Fix optional S3 path handling in imdb uploader

### DIFF
--- a/imdbapi.py
+++ b/imdbapi.py
@@ -139,8 +139,14 @@ def main():
     date = datetime.now().strftime("%Y%m%d")
 
     # Upload files to AWS S3
+    # Handle optional object_name correctly when constructing the
+    # remote path. If object_name was not provided, avoid performing
+    # string concatenation on None which would raise a TypeError.
+    remote_prefix = '' if object_name is None else object_name
+    remote_prefix += date + '/'
+
     for uf in unzipped_files:
-        awsapi.upload_file(bucket_name, dir, uf, object_name+date+'/')
+        awsapi.upload_file(bucket_name, dir, uf, remote_prefix)
         #os.remove(uf)
 
 


### PR DESCRIPTION
## Summary
- fix TypeError when `imdbapi.py` is executed without `--object_name`

## Testing
- `pytest -q`
- `python -m py_compile imdbapi.py`


------
https://chatgpt.com/codex/tasks/task_e_684078ec50988333ab5b87a2bfbe2993