### PR TITLE
Fix object_name argument

### DIFF
--- a/process_brfss_data.py
+++ b/process_brfss_data.py
@@ -381,7 +381,7 @@ def main():
         print('Issue with file downloading from {0}'.format(data_file_url))
 
     print('Uploading file to S3 ...')
-    awsapi.upload_file(bucket_name, dir, zip_fn, dir)
+    awsapi.upload_file(bucket_name, dir, zip_fn, object_name)
 
     print('Setting up ES environment ...')
     service = 'es'


### PR DESCRIPTION
## Summary
- use `object_name` when uploading BRFSS data to S3
- keep trailing slash handling for the S3 object name

## Testing
- `python3 -m py_compile process_brfss_data.py awsapi.py`


------
https://chatgpt.com/codex/tasks/task_e_6840821e9b2883339668a6a0cfade63f